### PR TITLE
Fixed typo

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ title: Sitzungsprotokolle der FSI Lehramt Informatik
 email: fsi-lehramt-informatik@fau.de
 description: >- # this means to ignore newlines until "baseurl:"
   Auf dieser Seite sammeln wir seit dem 16.10.2024 unsere Sitzungsprotokolle.
-  Diese erscheinen im Rahmen eines Blocks, den man auch per RSS-Feed abonnieren
+  Diese erscheinen im Rahmen eines Blogs, den man auch per RSS-Feed abonnieren
   kann.
 baseurl: "/Protokolle" # the subpath of your site, e.g. /blog
 url: "https://fsi-la-inf.github.io" # the base hostname & protocol for your site, e.g. http://example.com


### PR DESCRIPTION
Fixed typo in footer: blocks -> blogs